### PR TITLE
Fix calc_depth_from_surfaces_on_grid to pass new p argument (fixes #5)

### DIFF
--- a/voxeldepths_from_surfaces.py
+++ b/voxeldepths_from_surfaces.py
@@ -330,6 +330,7 @@ def calc_depth_from_surfaces_on_grid(surf_white, area_white, surf_pial, area_pia
                         area_white,
                         area_pial,
                         bounding_prisms,
+                        None,
                         method)
                 )(roi_idx) for roi_idx in roi))
 


### PR DESCRIPTION
This commit updates the call in calc_depth_from_surfaces_on_grid to pass the new `p` argument. 
Fixes #5.